### PR TITLE
Update monthly-meeting-emcee-howto with URL's

### DIFF
--- a/monthly-meeting-emcee-howto
+++ b/monthly-meeting-emcee-howto
@@ -1,7 +1,7 @@
 how to run COhPy meeting
 
-show cohpy.org on screens until presentation begins
-write Brazenhead address on whiteboards
+show cohpy.org (http://www.cohpy.org/) on screens until presentation begins
+write Brazenhead address (1027 W. Fifth Ave.) on whiteboards
 
 show meeting schedule on screens:
 
@@ -30,6 +30,7 @@ Be sure to respond to meetup so Pillar knows how much pizza to order.
 (don't forget to add cohpy and techlifecolumbus counts)
 
 mention cohpy.org and technical mailing list
+	(https://mail.python.org/mailman/listinfo/centraloh)
 
 who is here for first time, please raise your hand
 
@@ -52,4 +53,4 @@ work
 then presentations
 
 then adjourn by 8:00pm to brazenhead
-show brazenhead web page on displays
+show brazenhead web page on displays (http://www.hdrestaurants.com/brazenhead/5thavenue/)


### PR DESCRIPTION
Add URL's for cohpy.org, technical mailing list, and Brazenhead.  Also added the address for Brazenhead.